### PR TITLE
fix: correct better-sqlite3 type usage

### DIFF
--- a/client/pages/Admin.tsx
+++ b/client/pages/Admin.tsx
@@ -68,7 +68,7 @@ export default function Admin() {
   const [showApiDiagnostics, setShowApiDiagnostics] = useState(false);
   const [newStreet, setNewStreet] = useState("");
   const [selectedDistrict, setSelectedDistrict] = useState("");
-  const [streetToDistrictMap, setStreetToDistrictMap] = useState({});
+  const [streetToDistrictMap, setStreetToDistrictMap] = useState<Record<string, string>>({});
   const [mlModuleStatus, setMLModuleStatus] = useState({
     botasaurus_ready: false,
     lightautoml_trained: false,

--- a/client/pages/Statistics.tsx
+++ b/client/pages/Statistics.tsx
@@ -24,7 +24,13 @@ interface StatisticsData {
   owner_percentage: number;
   districts: { [key: string]: number };
   price_ranges: { [key: string]: number };
-  monthly_data: Array<{ month: string; count: number; avg_price: number }>;
+  monthly_data: Array<{
+    month: string;
+    count: number;
+    avg_price: number;
+    date?: string;
+    price_per_sqm?: number;
+  }>;
   top_streets: Array<{ street: string; count: number; avg_price: number }>;
 }
 

--- a/server/database.ts
+++ b/server/database.ts
@@ -1,8 +1,9 @@
 import Database from 'better-sqlite3';
+import type { Database as BetterSqlite3Database } from 'better-sqlite3';
 import { join } from 'path';
 
 // Initialize SQLite database lazily
-let db: Database | null = null;
+let db: BetterSqlite3Database | null = null;
 
 const getDatabase = () => {
   if (!db) {

--- a/server/routes/scraping.ts
+++ b/server/routes/scraping.ts
@@ -13,6 +13,8 @@ import { safeJson } from "../../shared/safe-parser";
 
 // Note: Safe JSON parsing is now handled by the centralized safeFetch function from shared/config.ts
 
+const pythonBackendUrl = API_CONFIG.BASE_URL;
+
 // Ensure database is initialized (will be called when first route is accessed)
 const ensureDatabase = () => {
   try {


### PR DESCRIPTION
## Summary
- explicitly import better-sqlite3 Database type for proper typing
- type street-to-district map and monthly trends data; define python backend URL constant

## Testing
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899d4dccf28832fb97523ec7c876f55