### PR TITLE
fix: stabilize fly frontend deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,8 @@ dist-ssr
 
 .config/
 !.env
+
+# Ignore any Fly.io auto-generated config
+fly.toml
+.fly.toml
+fly.tmp.toml

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -11,22 +11,17 @@ COPY yarn.lock* ./
 RUN echo "=== Node/NPM versions ===" && node -v && npm -v || true
 RUN echo "=== ls -la /app (before install) ===" && ls -la
 
-# 2) Стійка установка залежностей з видимими логами
-#    - якщо є package-lock.json -> npm ci
-#    - якщо є pnpm/yarn lock -> використовуємо corepack
-#    - інакше -> npm install
+# 2) Стійка установка залежностей з fallback
+#    - намагаємось npm ci, якщо є package-lock.json
+#    - якщо npm ci падає або lock-файл відсутній → npm install
 RUN if [ -f package-lock.json ]; then \
       echo "Using npm ci (lockfile found)"; \
-      npm ci --no-audit --no-fund --loglevel=verbose || (echo 'npm ci failed'; exit 1); \
-    elif [ -f pnpm-lock.yaml ]; then \
-      echo "Using pnpm (lockfile found)"; \
-      corepack enable && pnpm i --frozen-lockfile || (echo 'pnpm install failed'; exit 1); \
-    elif [ -f yarn.lock ]; then \
-      echo "Using yarn (lockfile found)"; \
-      corepack enable && yarn install --frozen-lockfile || (echo 'yarn install failed'; exit 1); \
+      npm ci --no-audit --no-fund --loglevel=verbose || \ 
+      (echo 'npm ci failed, falling back to npm install'; \
+       npm install --no-audit --no-fund --loglevel=verbose); \
     else \
-      echo "No lockfile, using npm install"; \
-      npm install --no-audit --no-fund --loglevel=verbose || (echo 'npm install failed'; exit 1); \
+      echo "No package-lock.json, using npm install"; \
+      npm install --no-audit --no-fund --loglevel=verbose; \
     fi
 
 # 3) Копіюємо решту коду (щоб кешувався install)

--- a/deploy-frontend.sh
+++ b/deploy-frontend.sh
@@ -1,13 +1,18 @@
 #!/bin/bash
 
 # Деплой фронтенда на Fly.io
-set -e
+set -euo pipefail
+
+# Блокуємо будь-яке auto-launch від Fly
+export FLY_NO_LAUNCH=1
+# Прибираємо потенційно згенеровані конфіги
+rm -f fly.toml .fly.toml fly.tmp.toml 2>/dev/null || true
 
 echo "🚀 Deploying Glow Nest Frontend to Fly.io..."
 
 # Перевірка локальної збірки
 echo "📦 Testing local build..."
-npm run build:client
+npm run build
 
 if [ $? -eq 0 ]; then
     echo "✅ Local build successful"

--- a/package.json
+++ b/package.json
@@ -12,10 +12,9 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "npm run build:client",
-    "build:client": "vite build",
+    "build": "vite build",
     "build:server": "vite build --config vite.config.server.ts",
-    "build:full": "npm run build:client && npm run build:server",
+    "build:full": "npm run build && npm run build:server",
     "start": "node dist/server/node-build.mjs",
     "test": "vitest --run",
     "format.fix": "prettier --write .",


### PR DESCRIPTION
## Summary
- ensure flyctl only uses explicit config and ignore auto-generated fly.toml
- add npm ci→install fallback and louder logging in Dockerfile.frontend
- simplify build script to `vite build` for client-only output
- deploy script disables auto-launch and cleans up stray configs

## Testing
- `npm run build`
- `npm test`
- `bash deploy-frontend.sh` *(fails: fly: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a802384fc832f96d0c691ea4db0d3